### PR TITLE
Make the new cost-of-velocity advanced unit display respect velocity unit chosen in the options.

### DIFF
--- a/app/scripts/services/options.coffee
+++ b/app/scripts/services/options.coffee
@@ -25,7 +25,7 @@ angular.module('swarmApp').factory 'Options', ($log, util, env, game, $location)
     addvunit 'min', 'minute', 'minutes', 60
     addvunit 'hr', 'hour', 'hours', 60 * 60
     addvunit 'day', 'day', 'days', 60 * 60 * 24
-    addvunit 'warp', 'Swarmwarp', 'Swarmwarp', -> game.upgrade('swarmwarp').effect[0].output()
+    addvunit 'warp', 'Swarmwarp', 'Swarmwarps', -> game.upgrade('swarmwarp').effect[0].output()
 
   maybeSet: (field, val, valid) ->
     if val?

--- a/app/views/directive-unit.html
+++ b/app/views/directive-unit.html
@@ -104,11 +104,11 @@ Numbers with suffixes work: '23 billion', '23b', or '23e12'.">
         </span>
       </p>
       <p ng-if="options.showAdvancedUnitData() && cur.maxCostMetOfVelocity().greaterThan(0)">
-        <span ng-if="cur.maxCostMetOfVelocity().times(cur.twinMult()).greaterThanOrEqualTo(1)">
-          You can {{cur.unittype.verb}} {{cur.maxCostMetOfVelocity().times(cur.twinMult())|longnum}} more {{cur.maxCostMetOfVelocity().times(cur.twinMult()).equals(1) ? cur.unittype.label : cur.unittype.plural}} every second, using
+        <span ng-if="cur.maxCostMetOfVelocity().times(cur.twinMult()).times(options.getVelocityUnit({unit:cur}).mult).greaterThanOrEqualTo(1)">
+          You can {{cur.unittype.verb}} {{cur.maxCostMetOfVelocity().times(cur.twinMult()).times(options.getVelocityUnit({unit:cur}).mult)|longnum}} {{cur.maxCostMetOfVelocity().times(cur.twinMult()).times(options.getVelocityUnit({unit:cur}).mult).equals(1) ? cur.unittype.label : cur.unittype.plural}} every {{options.getVelocityUnit({unit:cur}).label}}, using
         </span>
-        <span ng-if="cur.maxCostMetOfVelocity().times(cur.twinMult()).lessThan(1)">
-          You can {{cur.unittype.verb}} one {{cur.unittype.label}} every {{cur.maxCostMetOfVelocityReciprocal().dividedBy(cur.twinMult())|longnum}} seconds, using
+        <span ng-if="cur.maxCostMetOfVelocity().times(cur.twinMult()).times(options.getVelocityUnit({unit:cur}).mult).lessThan(1)">
+          You can {{cur.unittype.verb}} one {{cur.unittype.label}} every {{cur.maxCostMetOfVelocityReciprocal().dividedBy(cur.twinMult()).dividedBy(options.getVelocityUnit({unit:cur}).mult)|longnum}} {{cur.maxCostMetOfVelocityReciprocal().dividedBy(cur.twinMult()).dividedBy(options.getVelocityUnit({unit:cur}).mult).equals(1) ? options.getVelocityUnit({unit:cur}).label : options.getVelocityUnit({unit:cur}).plural}}, using
         </span>
         
         <span ng-repeat="cost in cur.eachCost()">


### PR DESCRIPTION
Re: reddit bug report https://www.reddit.com/r/swarmsim/comments/335s8n/uiux_bug_sort_of_setting_velocity_format_doesnt/ I realized the unit-per-velocity code ignores a user preference that I honestly hadn't realized existed. Fixed that - it now shows unit velocity relative to the user's chosen unit.

The Angular is now *astonishingly* ugly. It's probably maintainable right now, barely, but I wouldn't want to modify it much more without cleaning it up. Unfortunately I don't know the right code conventions for cleaning up Angular - should this get turned into a function in Unit? Is there a way to make variables in Angular? Is that, like, a super-bad-idea?

If I end up mucking with this code much more I am going to have to ask you for advice.