### PR TITLE
remove reddit references

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,12 @@
     "[typescriptreact]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "files.exclude": {
+        "swarmsim-coffee/archive": true,
+    },
+    "search.exclude": {
+        // symlink
+        "swarmsim-coffee/app/swarmsim-ts": true,
+        "swarmsim-coffee/changelog.html": true
+    }
 }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ and [other libraries](https://github.com/swarmsim/swarm/blob/master/bower.json)
 packaged by [Bower](http://bower.io/).
 Inspired by [the best Starcraft race](https://en.wikipedia.org/wiki/Races_of_StarCraft#The_Zerg "I haven't violated copyright I think, please don't sue me Blizz").
 
-- Community [subreddit](http://www.reddit.com/r/swarmsim/) and [wiki](http://www.reddit.com/r/swarmsim/wiki/).
 - [Spreadsheet with game data](https://docs.google.com/spreadsheets/d/1ughCy983eK-SPIcDYPsjOitVZzY10WdI2MGGrmxzxF4/pubhtml),
   imported by [Tabletop](https://github.com/jsoma/tabletop).
   [Edit it, if you think you can](https://docs.google.com/spreadsheets/d/1ughCy983eK-SPIcDYPsjOitVZzY10WdI2MGGrmxzxF4/edit "spoiler: you can't").

--- a/swarmsim-coffee/app/views/changelog.html
+++ b/swarmsim-coffee/app/views/changelog.html
@@ -27,6 +27,17 @@
     </div>
     <div id="changelog11x" class="panel-collapse collapse in">
 <div class="panel-body">
+  <h4>1.1.16<span>2023/6/16</span></h4>
+  <ul>
+    <li>Removed all links to the community website.</li>
+    <ul>
+      <li>The community website's host has done some Bad Things recently. I can't continue to support them.</li>
+      <li>I'm not providing a replacement. This late in the game's life, I don't think a new official community is necessary anymore.</li>
+    </ul>
+    <li>Rewrote one achievement's text.</li>
+  </ul>
+</div>
+<div class="panel-body">
   <h4>1.1.15<span>2022/12/15</span></h4>
   <ul>
     <li>Some invisible backend changes.</li>
@@ -60,7 +71,8 @@
 <div class="panel-body">
   <h4>1.1.10<span>2018/06/05</span></h4>
   <ul>
-    <li>Soon, swarmsim.github.io will begin encouraging players to <a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/8oik0y/swarmsimgithubio_is_moving_to_wwwswarmsimcom/">move to www.swarmsim.com</a>. This will be visible in a day or two. (Kongregate is unchanged.)</li>
+    <!-- <li>Soon, swarmsim.github.io will begin encouraging players to <a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/8oik0y/swarmsimgithubio_is_moving_to_wwwswarmsimcom/">move to www.swarmsim.com</a>. This will be visible in a day or two. (Kongregate is unchanged.)</li> -->
+    <li>Soon, swarmsim.github.io will begin encouraging players to move to www.swarmsim.com. This will be visible in a day or two. (Kongregate is unchanged.)</li>
     <li>Some small bugfixes for screen readers.</li>
   </ul>
 </div>
@@ -68,7 +80,8 @@
   <h4>1.1.9<span>2018/06/04</span></h4>
   <ul>
   <!-- <li>The swarmsim.github.io version strongly encourages you to move to www.swarmsim.com. (Kongregate is unchanged.)</li> -->
-    <li>The game's now playable on www.swarmsim.com. <a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/8oik0y/swarmsimgithubio_is_moving_to_wwwswarmsimcom/">In the near future, swarmsim.github.io will be moving there</a>. (Kongregate is unchanged.)</li>
+    <!-- <li>The game's now playable on www.swarmsim.com. <a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/8oik0y/swarmsimgithubio_is_moving_to_wwwswarmsimcom/">In the near future, swarmsim.github.io will be moving there</a>. (Kongregate is unchanged.)</li> -->
+    <li>The game's now playable on www.swarmsim.com. In the near future, swarmsim.github.io will be moving there. (Kongregate is unchanged.)</li>
   </ul>
 </div>
 <div class="panel-body">
@@ -293,7 +306,8 @@
 <h4>1.0.42<span>2015/04/01</span></h4>
 <ul>
   <li>Corrected the year shown in today's Exciting Announcement. I'm sure it's correct this time. Wouldn't make the same mistake twice, no chance of that.</li>
-  <li><a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/310qs2/ascending_on_april_1/">Buffed mutagen.</a></li>
+  <!-- <li><a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/310qs2/ascending_on_april_1/">Buffed mutagen.</a></li> -->
+  <li>Buffed mutagen.</li>
 </ul>
 <h4 title="Let's pretend that releasing .41 on 4/1 was part of my plan, and not just a coincidence.">1.0.41<span>2015/04/01</span></h4>
 <ul>
@@ -529,8 +543,10 @@
   <li>Changes to the contact-the-developer link:
   <ul>
     <li>Fixed a bug that prevented saved data from being properly sent with all messages. Saved games are now included as shortened URLs.</li>
-    <li>Instead of one form, there's now a "contact" page with three links: Reddit PM, email, or the anonymous feedback form. All of these include debug information for bug reports.</li>
-    <li>Removed the Reddit-username-or-email field from the anonymous feedback form, since you can now contact the developer directly by Reddit or email.</li>
+    <!-- <li>Instead of one form, there's now a "contact" page with three links: Reddit PM, email, or the anonymous feedback form. All of these include debug information for bug reports.</li> -->
+    <li>Instead of one form, there's now a "contact" page with three links: PM, email, or the anonymous feedback form. All of these include debug information for bug reports.</li>
+    <!-- <li>Removed the Reddit-username-or-email field from the anonymous feedback form, since you can now contact the developer directly by Reddit or email.</li> -->
+    <li>Removed the username-or-email field from the anonymous feedback form, since you can now contact the developer directly by email.</li>
   </ul></li>
 </ul>
 <h4>1.0.4<span>2015/02/13</span></h4>
@@ -554,7 +570,8 @@
 <ul>
   <li>Importing certain saved games from the test server should no longer work.</li>
 </ul>
-<h4>1.0.0 - <a href="https://www.reddit.com/r/swarmsim/comments/2vhiwp/v10_mutation_prestige_new_units_bigger_numbers_no/">release announcement</a><span>2015/02/10</span></h4>
+<!-- <h4>1.0.0 - <a href="https://www.reddit.com/r/swarmsim/comments/2vhiwp/v10_mutation_prestige_new_units_bigger_numbers_no/">release announcement</a><span>2015/02/10</span></h4> -->
+<h4>1.0.0<span>2015/02/10</span></h4>
 <ul>
   <li>Removed the "we're testing, your progress may be reset" warning. Version 1.0 means no more (intentional) resets, ever.</li>
   <li>The meat tab looks different. Late game units have been renamed, and there's several new units.</li>
@@ -726,7 +743,8 @@
 </ul>
 <h4>1.0.0-publictest9<span>2015/01/21</span></h4>
 <ul>
-  <li><b><a href="https://www.reddit.com/r/swarmsim/comments/2t5m25/v100publictest8_test_server_resetting_soon/">Your progress has been reset!</a></b></li>
+  <!-- <li><b><a href="https://www.reddit.com/r/swarmsim/comments/2t5m25/v100publictest8_test_server_resetting_soon/">Your progress has been reset!</a></b></li> -->
+  <li><b>Your progress has been reset!</b></li>
   <li>All twin upgrades and achievements now use the correct unit names.</li>
   <li>Lots of new achievements are now available. You should see achievements for all new units, ascending, and unlocking mutations.</li>
   <li>Queens and nests are visible immediately after ascending.</li>
@@ -759,7 +777,8 @@
   <li>The 1e300 unit cap is more thorough now</li>
   <li>Updated the description of bats to reflect their cost change</li>
 </ul>
-<h4>1.0.0-publictest4 - <a href="https://www.reddit.com/r/swarmsim/comments/2ssnw5/help_test_v10_mutation_and_new_units/">release announcement</a><span>2015/01/17</span></h4>
+<!-- <h4>1.0.0-publictest4 - <a href="https://www.reddit.com/r/swarmsim/comments/2ssnw5/help_test_v10_mutation_and_new_units/">release announcement</a><span>2015/01/17</span></h4> -->
+<h4>1.0.0-publictest4<span>2015/01/17</span></h4>
 <ul>
   <li>0.2.x saves no longer need to refresh the page to get their mutagen</li>
   <li>One new mutation; several rebalanced mutations</li>
@@ -920,17 +939,20 @@
 <ul>
   <li>Earning an achievement now correctly updates larvae/sec.</li>
 </ul>
-<h4>0.2.0 - <a href="https://www.reddit.com/r/swarmsim/comments/2hb0lv/020_reset_and_release_date_friday_september_26/">release announcement</a><span>2014/09/26</span></h4>
+<!-- <h4>0.2.0 - <a href="https://www.reddit.com/r/swarmsim/comments/2hb0lv/020_reset_and_release_date_friday_september_26/">release announcement</a><span>2014/09/26</span></h4> -->
+<h4>0.2.0<span>2014/09/26</span></h4>
 <ul>
   <li><b>Full Reset</b> - everyone's game has been restarted. If you like, <a href="archive/0.1.37">you may continue to play your 0.1.x save for a while longer here</a>, but you won't get any new features.</li>
-  <li><b><a href="https://www.reddit.com/r/swarmsim/comments/2frtef/upcoming_inject_larvae_changes_cost_no_longer/">Energy</a></b> - buy your first nexus for 3.3 trillion meat to begin generating energy. Energy is used for special abilities.
+  <!-- <li><b><a href="https://www.reddit.com/r/swarmsim/comments/2frtef/upcoming_inject_larvae_changes_cost_no_longer/">Energy</a></b> - buy your first nexus for 3.3 trillion meat to begin generating energy. Energy is used for special abilities. -->
+  <li><b>Energy</b> - buy your first nexus for 3.3 trillion meat to begin generating energy. Energy is used for special abilities.
   <ul>
     <li>Inject Larvae has been renamed to Clone Larvae, now costs energy, no longer increases in cost, requires 4 nexus to cast, and has a cap based on your larvae gained per second.</li>
     <li>There are several other new energy-based abilities which generate meat, larvae, and territory quickly.</li>
     <li>Cocooning is no longer available until Clone Larvae is unlocked, and its description is now clearer about how it's used.</li>
   </ul>
   </li>
-  <li><b><a href="https://www.reddit.com/r/swarmsim/comments/2gu9py/upcoming_020_changes_empowered_military_units/">Empowered Military Units</a></b> - you can now upgrade your territory-generating units to a higher tier, increasing both their cost and territory gains and adding a suffix to their name. A tier 2 swarmling - Swarmling II - is more expensive, and stronger, than the final unupgraded military unit.
+  <!-- <li><b><a href="https://www.reddit.com/r/swarmsim/comments/2gu9py/upcoming_020_changes_empowered_military_units/">Empowered Military Units</a></b> - you can now upgrade your territory-generating units to a higher tier, increasing both their cost and territory gains and adding a suffix to their name. A tier 2 swarmling - Swarmling II - is more expensive, and stronger, than the final unupgraded military unit. -->
+  <li><b>Empowered Military Units</b> - you can now upgrade your territory-generating units to a higher tier, increasing both their cost and territory gains and adding a suffix to their name. A tier 2 swarmling - Swarmling II - is more expensive, and stronger, than the final unupgraded military unit.
   <ul>
     <li>Cost, and territory per second, for unupgraded military units have both been increased.</li>
     <li>Expansions are much more expensive.</li>
@@ -969,7 +991,8 @@
 </ul>
 <h4>0.1.35 <span>2014/09/23</span></h4>
 <ul>
-  <li><a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/2hb0lv/020_reset_and_release_date_friday_september_26/">v0.2.0 announcement.</a></li>
+  <!-- <li><a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/2hb0lv/020_reset_and_release_date_friday_september_26/">v0.2.0 announcement.</a></li> -->
+  <li>v0.2.0 announcement.</li>
 </ul>
 <h4>0.1.34 <span>2014/09/23</span></h4>
 <ul>
@@ -983,7 +1006,8 @@
 </ul>
 <h4>0.1.32 <span>2014/09/19</span></h4>
 <ul>
-  <li>Better savestate recovery if another accidental reset happens. <a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/2gupcf/0130_deleted_my_save/ckn9hxi">Read more here</a>.</li>
+  <!-- <li>Better savestate recovery if another accidental reset happens. <a target="_blank" href="https://www.reddit.com/r/swarmsim/comments/2gupcf/0130_deleted_my_save/ckn9hxi">Read more here</a>.</li> -->
+  <li>Better savestate recovery if another accidental reset happens.</li>
 </ul>
 <h4>0.1.31 <span>2014/09/19</span></h4>
 <ul>

--- a/swarmsim-coffee/app/views/changelog.html
+++ b/swarmsim-coffee/app/views/changelog.html
@@ -27,7 +27,7 @@
     </div>
     <div id="changelog11x" class="panel-collapse collapse in">
 <div class="panel-body">
-  <h4>1.1.16<span>2023/6/16</span></h4>
+  <h4>1.1.16<span>2023/6/20</span></h4>
   <ul>
     <li>Removed all links to the community website.</li>
     <ul>

--- a/swarmsim-coffee/app/views/contact.html
+++ b/swarmsim-coffee/app/views/contact.html
@@ -1,20 +1,12 @@
 <tabs></tabs>
 
-<h2 class="contact-title"><span><a target="_blank" href="https://www.reddit.com/r/swarmsim">Contact the Swarm Simulator developer</a></span></h2>
-
-<p class="well"><a target="_blank" href="https://www.reddit.com/r/swarmsim/submit?selftext=true">Posting</a> on the <a target="_blank" href="https://www.reddit.com/r/swarmsim">Swarm Simulator subreddit</a> is the best way to reach the developer! I read everything written there, even if I don't always reply.</p>
-
-<!-- <p><a class="btn btn-link" target="_blank" href="/repair">Is your Swarm Simulator browser tab reloading endlessly?</a></p> -->
+<h2 class="contact-title">Contact the Swarm Simulator developer</h2>
 
 <p><a class="btn btn-link" target="_blank" href="https://swarmsim.github.io/#/export">Did you play on the old website, swarmsim.github.io, and you're looking for your saved progress?</a></p>
 
-<p><a class="btn btn-link" target="_blank" href="https://www.reddit.com/r/swarmsim/comments/30ndt6/i_will_no_longer_restore_lost_saved_games/">Did you lose your saved progress some other way?</a></p>
-
-<p><small><button class="btn btn-link" data-toggle="collapse" data-target=".collapseEmail">Email the developer?</button></small></p>
-
-<div class="collapse collapseEmail well">
+<div class="well">
   <p>Please email me if you're having trouble with a crystal purchase, or if you're reporting an exploitable bug.</p>
-  <p>For most other topics, <b>I probably won't reply. Please post on Reddit instead.</b></p>
-  <p>Swarm Simulator is run in one human's free time. I love you and your feedback, I really do - but email is stressful, and takes more of my limited time than you think. The Reddit community really is very helpful!</p>
+  <p>For most other topics, <b>I probably won't reply.</b></p>
+  <p>Swarm Simulator is run in one human's free time. I love you and your feedback, I really do - but email is stressful, and takes more of my limited time than you think.</p>
   <p><a target="_blank" ng-href="{{mailtoUrl()}}">{{emailTo()}}</a></p>
 </div>

--- a/swarmsim-coffee/app/views/tabs.html
+++ b/swarmsim-coffee/app/views/tabs.html
@@ -50,9 +50,6 @@
       <!--li role="presentation"><a role="menuitem" tabindex="-1" href="#/news-archive">
         <span class="glyphicon glyphicon-bullhorn"></span> News
       </a></li-->
-      <li role="presentation"><a role="menuitem" tabindex="-1" href="http://reddit.com/r/swarmsim" target="_blank">
-        <span class="glyphicon glyphicon-user"></span> Community
-      </a></li>
       <li role="presentation"><a role="menuitem" tabindex="-1" href="#/contact">
         <span class="fa fa-comment"></span> Send Feedback
       </a></li>

--- a/swarmsim-coffee/package.json
+++ b/swarmsim-coffee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swarm",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Swarm Simulator - an incremental/idle game. Starting with only a few larvae and a small pile of meat, build a merciless swarm of giant alien bugs.",
   "repository": {
     "url": "http://github.com/erosson/swarm.git",

--- a/tables/src/achievement/data.test.ts
+++ b/tables/src/achievement/data.test.ts
@@ -6,14 +6,17 @@ import { orThrow } from "../util";
 test("data matches original-data, when it exists", () => {
   const originalByName = orThrow(C.sheetByName(originalData.achievements));
   for (let d of list) {
+    // skip achievements that have changed since the original
+    if (d.name === 'therightquestion') continue;
     const td = C.FromSpreadsheet.encode(d);
     const od = originalByName[d.name];
     expect(td).toHaveLength(od.length);
     expect(td).toEqual(od);
   }
 });
-test("data matches original-data, and all of it exists", () => {
-  expect(list.flatMap(C.FromSpreadsheet.encode)).toEqual(
-    originalData.achievements.elements
-  );
-});
+// achievements have changed since the original, and skipping just one is too hard, so disable the whole test
+//test("data matches original-data, and all of it exists", () => {
+//  expect(list.flatMap(C.FromSpreadsheet.encode)).toEqual(
+//    originalData.achievements.elements
+//  );
+//});

--- a/tables/src/achievement/data.ts
+++ b/tables/src/achievement/data.ts
@@ -2500,8 +2500,8 @@ const list: C.Achievement[] = [
     "name": "therightquestion",
     "l": {
       "description": "Ask the right question",
-      "label": "signs point to yes",
-      "longdesc": "The secret's out - read it on /r/swarmsim"
+      "label": "signs point to no",
+      "longdesc": "trying is the first step towards failure"
     },
     "points": 0,
     "requires": [


### PR DESCRIPTION
Remove all links to Reddit from the game. 

[Reddit is walling off their garden](https://www.reddit.com/r/reddit/comments/12qwagm/an_update_regarding_reddits_api/), and I cannot support it. [Their changes are pretty unpopular](https://www.reddit.com/r/Save3rdPartyApps/comments/1476ioa/reddit_blackout_2023_save_3rd_party_apps/).

In hindsight, I really should've self-hosted the community from the start! I think it's too late in the game's life for a new community to take off, so I'm not planning to provide a replacement. (I don't feel strongly about this - could be persuaded to create one.)

Waiting a bit to release this change, until I've settled some other details.

Also, rewrite the "sequel" achievement while I'm at it